### PR TITLE
Feature/89-featurepagination

### DIFF
--- a/frontend/src/Components/ui/MainStore/MainStore.tsx
+++ b/frontend/src/Components/ui/MainStore/MainStore.tsx
@@ -6,7 +6,7 @@ import { Item } from '@/Components/entity/item'
 import { useAppDispatch, useAppSelector } from '@/lib/hooks'
 import Grid from '../GridContainer/Grid'
 import { Pagination } from 'antd'
-import { selectFilter } from '@/lib/features/filter/filter'
+import { selectFilter, setLimit } from '@/lib/features/filter/filter'
 import { InputFetch } from '@/type/interfaceFilter'
 
 function MainStore() {
@@ -15,9 +15,9 @@ function MainStore() {
     const pages = useAppSelector(selectItems).totalPages
     const [currentPage, setCurrentPage] = useState<number>(0)
     const filter = useAppSelector(selectFilter) // Получаем параметры фильтрации из хранилища
-    const limit = 8 // Устанавливаем лимит
+    const limit = filter.limit
     const isInitialMount = useRef(true) // Ссылка, позволяющая определить, первый ли раз вызывается компонент
-
+    dispatch(setLimit(8))
     // Функция для обновления элементов
     const updateItems = () => {
         // Формируем объект inputFetch, учитывая выбор пользователя
@@ -29,7 +29,7 @@ function MainStore() {
             ...(filter.min_price ? { min_price: filter.min_price } : {}),
             ...(filter.category ? { category: filter.category } : {}),
             ...(filter.search ? { search: filter.search } : {}),
-            limit: limit,
+            ...(filter.limit ? { limit: filter.limit } : {}),
             // Добавляем свойство news только если оно true
         }
 
@@ -49,7 +49,7 @@ function MainStore() {
     }, [filter, dispatch, limit])
 
     let products = null // По умолчанию нет товаров
-    if (items) {
+    if (items && limit !== undefined) {
         // Ограничиваем количество элементов до limit с помощью slice
         const limitedItems = items.slice(
             currentPage * limit,

--- a/frontend/src/Components/ui/MainStore/MainStore.tsx
+++ b/frontend/src/Components/ui/MainStore/MainStore.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { fetchItems } from '@/lib/features/items/items'
 import { selectItems } from '@/lib/features/items/items'
 import { Item } from '@/Components/entity/item'
@@ -13,6 +13,7 @@ function MainStore() {
     const dispatch = useAppDispatch()
     const items = useAppSelector(selectItems).items
     const pages = useAppSelector(selectItems).totalPages
+    const [currentPage, setCurrentPage] = useState<number>(0)
     const filter = useAppSelector(selectFilter) // Получаем параметры фильтрации из хранилища
     const limit = 8 // Устанавливаем лимит
     const isInitialMount = useRef(true) // Ссылка, позволяющая определить, первый ли раз вызывается компонент
@@ -50,7 +51,10 @@ function MainStore() {
     let products = null // По умолчанию нет товаров
     if (items) {
         // Ограничиваем количество элементов до limit с помощью slice
-        const limitedItems = items.slice(0, limit)
+        const limitedItems = items.slice(
+            currentPage * limit,
+            currentPage * limit + limit,
+        )
         products = limitedItems.map((obj: any) => (
             <Item key={obj.id} disabled={true} {...obj}></Item>
         ))
@@ -68,13 +72,18 @@ function MainStore() {
             <Pagination
                 className="text-center"
                 showSizeChanger={false}
+                onChange={(page) => {
+                    setCurrentPage(page - 1)
+                }}
                 pageSize={
-                    items && items.lenght > 0
+                    items && Object.keys(items).length > 0
                         ? Object.keys(items).length / pages
                         : 1
                 }
                 total={
-                    items && items.lenght > 0 ? Object.keys(items).length : 1
+                    items && Object.keys(items).length > 0
+                        ? Object.keys(items).length
+                        : 1
                 }
             />
         </div>

--- a/frontend/src/lib/features/filter/filter.ts
+++ b/frontend/src/lib/features/filter/filter.ts
@@ -9,7 +9,6 @@ const initialState: InputFetch = {
     sale: false,
     max_price: 12000,
     min_price: 0,
-    currentPage: 0,
     limit: 100,
     category: '',
     search: ''
@@ -46,11 +45,11 @@ const filterSlice = createSlice({
         ) => {
             state.min_price = action.payload
         },
-        setCurrentPage(
+        setLimit(
             state,
-            action: PayloadAction<InputFetch['currentPage']>,
+            action: PayloadAction<InputFetch['limit']>,
         ) {
-            state.currentPage = action.payload
+            state.limit = action.payload
         },
         setCategory(
             state,
@@ -75,6 +74,7 @@ export const {
     setNews,
     setMaxPrice,
     setMinPrice,
+    setLimit,
     setSale,
     setCategory,
     setSearch,

--- a/frontend/src/lib/features/items/items.ts
+++ b/frontend/src/lib/features/items/items.ts
@@ -45,7 +45,6 @@ export const fetchItems = createAsyncThunk(
             sale: false,
             max_price: 12000,
             min_price: 0,
-            currentPage: 0,
             limit: 100,
             category: '',
             search: '',

--- a/frontend/src/type/interfaceFilter.ts
+++ b/frontend/src/type/interfaceFilter.ts
@@ -7,7 +7,6 @@ export interface InputFetch {
   sale?:boolean
   max_price?: number
   min_price?: number
-  currentPage?: number
   limit?: number
   category?: string,
   search?: string


### PR DESCRIPTION
This commit adds pagination to the MainStore component by introducing a new state variable `currentPage` and using it to slice the items array. The `onChange` handler for the Pagination component is also added to update the `currentPage` state. Additionally, the calculation of `pageSize` and `total` props for the Pagination component is updated to handle cases where the `items` array is empty or not yet loaded.